### PR TITLE
Added support for different Debian versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,16 @@ Then:
 ```
 git clone https://github.com/greizgh/bitwarden_rs-debian.git
 cd bitwarden_rs-debian
-./build.sh 1.10.0
+./build.sh -r 1.10.0
 ```
+
+The `build.sh`script will build bitwarden_rs for the same Debian version on which the script is executed.
+To compile for a different Debian version, specify the release name (e.g. Stretch, Buster) using the `-o` option.
+
+```
+./build.sh -o stretch
+```
+
 
 ## Post installation
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,12 @@ cd bitwarden_rs-debian
 ./build.sh -r 1.10.0
 ```
 
-The `build.sh`script will build bitwarden_rs for the same Debian version on which the script is executed.
+The `build.sh` script will build bitwarden_rs for the same Debian version which targets bitwarden_rs.
 To compile for a different Debian version, specify the release name (e.g. Stretch, Buster) using the `-o` option.
 
 ```
 ./build.sh -o stretch
 ```
-
 
 ## Post installation
 

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ while getopts ":r:o:" opt; do
   esac
 done
 if [ -z "$REF" ]; then REF="1.13.0"; fi
-if [ -z "$OS_VERSION_NAME" ]; then OS_VERSION_NAME=$(lsb_release -s -c); fi
+if [ -z "$OS_VERSION_NAME" ]; then OS_VERSION_NAME='buster'; fi
 
 # Clone bitwarden_rs
 if [ ! -d "$SRC" ]; then
@@ -50,5 +50,5 @@ sed -E "s/(FROM[[:space:]]*debian:)[^-]+(-.+)/\1${OS_VERSION_NAME}\2/g" -i "$DIR
 docker build -t bitwarden-deb "$DIR"
 
 CID=$(docker run -d bitwarden-deb)
-docker cp "$CID":/bitwarden_package/bitwarden-rs.deb "$DST/bitwarden_rs-$REF.deb"
+docker cp "$CID":/bitwarden_package/bitwarden-rs.deb "$DST/bitwarden_rs-${OS_VERSION_NAME}-${REF}.deb"
 docker rm "$CID"


### PR DESCRIPTION
When  I compiled the new 1.13 version I noticed that the bitwarden_rs binary crashes on my Debian server with the following error

```
/usr/local/bin/bitwarden_rs: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /usr/local/bin/bitwarden_rs)
```
The issue here is that since @dani-garcia upgraded the Rust version in the Dockerfile to 1.39 the underlying Debian version of the Docker image is changed to _Buster_, whereas my server is still running with _Stretch_. Debian _Strech_ still uses GLIBC 2.14 and there's is no backport of GLIBC 2.28.

Therefor I changed the build.sh file to support building bitwarden_rs for a specific target platform.
Two major changes were introduced:

1. you can specifiy the release of Bitwarden_rs via the `-r` option and the Debian target by the `-o` option. If the `-o` option is not specified the current version of Debian is determined by using `lsb_release -c -s`
2. Two new inplace `sed` commands adjust the `Dockerfile` for the selected Debian version. Luckily the Rust guys aligned their Docker image names to the Debian versions. So this was not a great hassle.

After that I was able to compile Bitwarden_Rs for different Debian versions, including for _Strech_ running on my server.

I changed the `README.md` file accordingly to the changes applied to `build.sh`