### PR TITLE
Fetch the newest upstream version from github api

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Make sure you have the required build dependencies:
 * docker
 * git
 * patch
+* curl
 
 Then:
 

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ while getopts ":r:o:d:" opt; do
     ;;
   esac
 done
-if [ -z "$REF" ]; then REF="1.15.0"; fi
+if [ -z "$REF" ]; then REF=$(curl -s https://api.github.com/repos/dani-garcia/bitwarden_rs/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 1-); fi
 if [ -z "$OS_VERSION_NAME" ]; then OS_VERSION_NAME='buster'; fi
 if [ -z "$DB_TYPE" ]; then DB_TYPE="sqlite"; fi
 


### PR DESCRIPTION
If the build version is not set via e.g. `-r 1.14.0` the script will use a hardcoded version that needs to be updated with every upstream release. This PR will fetch the latest upstream release via github api and use that as default build version.

closes #16 