### PR TITLE
Insert warning in config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,8 @@ CONFIG="$DIR/debian/config.env"
 cp "$SRC/.env.template" "$CONFIG"
 sed -i "s#\# DATA_FOLDER=data#DATA_FOLDER=/var/lib/bitwarden_rs#" "$CONFIG"
 sed -i "s#\# WEB_VAULT_FOLDER=web-vault/#WEB_VAULT_FOLDER=/usr/share/bitwarden_rs/web-vault/#" "$CONFIG"
+sed -i "s/Uncomment any of the following lines to change the defaults/Uncomment any of the following lines to change the defaults\n\n## Warning\n## The default systemd-unit does not allow any custom directories.\n## Be sure to check if the service has appropriate permissions before you set custom paths./g" "$CONFIG"
+
 
 mkdir -p "$DST"
 


### PR DESCRIPTION
The shipped systemd-unit contains default values that could give the users a hard time starting the service. This warning should make things more clear. Especially if non standard directories are to be used.

closes #14 