### PR TITLE
Added support for dynamically configure DEB package creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ git/
 dist/
 debian/config.env
 debian/control
-debian/vaultwarden.service
+debian/*.service
+debian/conffiles
+debian/postinst
 Dockerfile

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SRC="$DIR/git"
 DST="$DIR/dist"
 
-while getopts ":r:o:d:a:" opt; do
+while getopts ":r:o:d:a:p:i:u:e:" opt; do
   case $opt in
     r) REF="$OPTARG"
     ;;
@@ -16,7 +16,15 @@ while getopts ":r:o:d:a:" opt; do
     ;;
     a) ARCH_DIR="$OPTARG"
     ;;
-    \?) echo "Invalid option -$OPTARG" >&2
+    p) PACKAGENAME="$OPTARG"
+    ;;
+    i) PACKAGEDIR="$OPTARG"
+    ;;
+    u) SERVICEUSER="$OPTARG"
+    ;;
+    e) EXECUTABLENAME="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2 ; exit
     ;;
   esac
 done
@@ -26,45 +34,71 @@ if [ -z "$DB_TYPE" ]; then DB_TYPE="sqlite"; fi
 if [ -z "$ARCH_DIR" ]; then ARCH_DIR="amd64"; fi
 ARCH=$ARCH_DIR
 if [[ "$ARCH" =~ ^arm ]]; then ARCH="armhf"; fi
+if [ -z "$PACKAGENAME" ]; then PACKAGENAME="vaultwarden"; fi
+if [ -z "$PACKAGEDIR" ]; then SERVICEUSER="vaultwarden"; fi
+if [ -z "$SERVICEUSER" ]; then SERVICEUSER="vaultwarden"; fi
+if [ -z "$EXECUTABLENAME" ]; then EXECUTABLENAME="$PACKAGEDIR"; fi
 
 # Clone vaultwarden
 if [ ! -d "$SRC" ]; then
   git clone https://github.com/dani-garcia/vaultwarden.git "$SRC"
 fi
-cd "$SRC" || exit
+pushd "$SRC" || exit
 CREF="$(git branch | grep \* | cut -d ' ' -f2)"
 if [ "$CREF" != "$REF" ]; then
-  git fetch
-  git checkout "$REF" --force
+  git fetch || exit
+  git checkout "$REF" --force || exit
 else
-  git clean -d -f
-  git pull
+  git pull || exit
 fi
-cd - || exit
+git clean -d -f || exit
+popd || exit
+
+DEBIANDIR="$SRC/debian"
+mkdir -p "$DEBIANDIR"
+
+SEDCOMMANDS="
+s/@@PACKAGENAME@@/$PACKAGENAME/g
+s/@@PACKAGEDIR@@/$PACKAGEDIR/g
+s/@@SERVICEUSER@@/$SERVICEUSER/g
+s/@@EXECUTABLENAME@@/$EXECUTABLENAME/g
+"
 
 # Prepare EnvFile
-CONFIG="$DIR/debian/config.env"
+CONFIG="$DEBIANDIR/config.env"
 cp "$SRC/.env.template" "$CONFIG"
-sed -i "s#\# DATA_FOLDER=data#DATA_FOLDER=/var/lib/vaultwarden#" "$CONFIG"
-sed -i "s#\# WEB_VAULT_FOLDER=web-vault/#WEB_VAULT_FOLDER=/usr/share/vaultwarden/web-vault/#" "$CONFIG"
+sed -i "s#\# DATA_FOLDER=data#DATA_FOLDER=/var/lib/$PACKAGEDIR#" "$CONFIG"
+sed -i "s#\# WEB_VAULT_FOLDER=web-vault/#WEB_VAULT_FOLDER=/usr/share/$PACKAGEDIR/web-vault/#" "$CONFIG"
 sed -i "s/Uncomment any of the following lines to change the defaults/Uncomment any of the following lines to change the defaults\n\n## Warning\n## The default systemd-unit does not allow any custom directories.\n## Be sure to check if the service has appropriate permissions before you set custom paths./g" "$CONFIG"
+
+# Prepare conffiles
+sed conffiles.dist > $DEBIANDIR/conffiles -f <( echo "$SEDCOMMANDS" ) || exit
+chmod 644 $DEBIANDIR/conffiles
+
+# Prepare postinst
+sed postinst.dist > $DEBIANDIR/postinst -f <( echo "$SEDCOMMANDS" ) || exit
+chmod 755 $DEBIANDIR/postinst
 
 mkdir -p "$DST"
 
 # Prepare Dockerfile
-patch -i "$DIR/patch/$ARCH_DIR/Dockerfile.patch" "$SRC/docker/$ARCH_DIR/Dockerfile" --verbose -o "$DIR/Dockerfile" || exit
+sed "$DIR/patch/$ARCH_DIR/Dockerfile.patch" -f <( echo "$SEDCOMMANDS" ) | \
+patch "$SRC/docker/$ARCH_DIR/Dockerfile" --verbose -o "$DIR/Dockerfile" || \
+exit
+
 sed -E "s/(FROM[[:space:]]*rust:)[^[:space:]]+(.+)/\1${OS_VERSION_NAME}\2/g" -i "$DIR/Dockerfile"
 sed -E "s/(FROM[[:space:]]*debian:)[^-]+(-.+)/\1${OS_VERSION_NAME}\2/g" -i "$DIR/Dockerfile"
 
 # Prepare Controlfile
-CONTROL="$DIR/debian/control"
+CONTROL="$DEBIANDIR/control"
 cp "$DIR/control.dist" "$CONTROL"
+sed -i "s/@@PACKAGENAME@@/$PACKAGENAME/g" "$CONTROL"
 sed -i "s/Version:.*/Version: $REF-1/" "$CONTROL"
 sed -i "s/Architecture:.*/Architecture: $ARCH/" "$CONTROL"
 
 # Prepare Systemd-unit
-SYSTEMD_UNIT="$DIR/debian/vaultwarden.service"
-cp "$DIR/service.dist" "$SYSTEMD_UNIT"
+SYSTEMD_UNIT="$DEBIANDIR/$EXECUTABLENAME.service"
+sed "$DIR/service.dist" > "$SYSTEMD_UNIT" -f <( echo "$SEDCOMMANDS" ) || exit
 if [ "$DB_TYPE" = "mysql" ]; then
   sed -i "s/After=network.target/After=network.target mysqld.service\nRequires=mysqld.service/g" "$SYSTEMD_UNIT"
 elif [ "$DB_TYPE" = "postgresql" ]; then
@@ -72,10 +106,8 @@ elif [ "$DB_TYPE" = "postgresql" ]; then
 fi
 
 echo "[INFO] docker build -t vaultwarden-deb "$DIR" --build-arg DB=$DB_TYPE"
-cp -r "$DIR/debian" "$SRC/debian"
 docker build -t vaultwarden-deb "$SRC" --build-arg DB=$DB_TYPE --target dpkg -f "$DIR/Dockerfile"
-pushd "$SRC"; git clean -fd; popd
 
 CID=$(docker run -d vaultwarden-deb)
-docker cp "$CID":/vaultwarden_package/vaultwarden.deb "$DST/vaultwarden-${OS_VERSION_NAME}-${REF}-${DB_TYPE}-${ARCH_DIR}.deb"
+docker cp "$CID:/vaultwarden_package/${PACKAGEDIR}.deb" "$DST/${PACKAGEDIR}-${OS_VERSION_NAME}-${REF}-${DB_TYPE}-${ARCH_DIR}.deb"
 docker rm "$CID"

--- a/conffiles.dist
+++ b/conffiles.dist
@@ -1,0 +1,2 @@
+/etc/@@PACKAGEDIR@@/Rocket.toml
+/etc/@@PACKAGEDIR@@/config.env

--- a/control.dist
+++ b/control.dist
@@ -1,4 +1,4 @@
-Package: vaultwarden
+Package: @@PACKAGENAME@@
 Architecture: -
 Maintainer: Greizgh <greizgh+vaultwarden@ephax.org>
 Priority: optional

--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,2 +1,0 @@
-/etc/vaultwarden/Rocket.toml
-/etc/vaultwarden/config.env

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,5 +1,0 @@
-#!/bin/sh
-DIR_MODE=0700 adduser --system --home /var/lib/vaultwarden vaultwarden
-chmod 700 /var/lib/vaultwarden
-chmod 600 /etc/vaultwarden/config.env
-chmod 600 /etc/vaultwarden/Rocket.toml

--- a/patch/amd64/Dockerfile.patch
+++ b/patch/amd64/Dockerfile.patch
@@ -10,17 +10,17 @@
 +RUN mkdir -p /vaultwarden_package/DEBIAN
 +RUN mkdir -p /vaultwarden_package/usr/local/bin
 +RUN mkdir -p /vaultwarden_package/usr/lib/systemd/system
-+RUN mkdir -p /vaultwarden_package/etc/vaultwarden
-+RUN mkdir -p /vaultwarden_package/usr/share/vaultwarden
++RUN mkdir -p /vaultwarden_package/etc/@@PACKAGEDIR@@
++RUN mkdir -p /vaultwarden_package/usr/share/@@PACKAGEDIR@@
 +
 +WORKDIR /vaultwarden_package
 +COPY debian/control /vaultwarden_package/DEBIAN/control
 +COPY debian/postinst /vaultwarden_package/DEBIAN/postinst
 +COPY debian/conffiles /vaultwarden_package/DEBIAN/conffiles
-+COPY Rocket.toml /vaultwarden_package/etc/vaultwarden
-+COPY debian/config.env /vaultwarden_package/etc/vaultwarden
-+COPY debian/vaultwarden.service /vaultwarden_package/usr/lib/systemd/system
-+COPY --from=vault /web-vault /vaultwarden_package/usr/share/vaultwarden/web-vault
-+COPY --from=build app/target/release/vaultwarden /vaultwarden_package/usr/local/bin
++COPY Rocket.toml /vaultwarden_package/etc/@@PACKAGEDIR@@
++COPY debian/config.env /vaultwarden_package/etc/@@PACKAGEDIR@@
++COPY debian/@@EXECUTABLENAME@@.service /vaultwarden_package/usr/lib/systemd/system
++COPY --from=vault /web-vault /vaultwarden_package/usr/share/@@PACKAGEDIR@@/web-vault
++COPY --from=build app/target/release/vaultwarden /vaultwarden_package/usr/local/bin/@@EXECUTABLENAME@@
 +
-+RUN dpkg-deb --build . vaultwarden.deb
++RUN dpkg-deb --build . @@PACKAGEDIR@@.deb

--- a/patch/armv7/Dockerfile.patch
+++ b/patch/armv7/Dockerfile.patch
@@ -10,17 +10,17 @@
 +RUN mkdir -p /vaultwarden_package/DEBIAN
 +RUN mkdir -p /vaultwarden_package/usr/local/bin
 +RUN mkdir -p /vaultwarden_package/usr/lib/systemd/system
-+RUN mkdir -p /vaultwarden_package/etc/vaultwarden
-+RUN mkdir -p /vaultwarden_package/usr/share/vaultwarden
++RUN mkdir -p /vaultwarden_package/etc/@@PACKAGEDIR@@
++RUN mkdir -p /vaultwarden_package/usr/share/@@PACKAGEDIR@@
 +
 +WORKDIR /vaultwarden_package
 +COPY debian/control /vaultwarden_package/DEBIAN/control
 +COPY debian/postinst /vaultwarden_package/DEBIAN/postinst
 +COPY debian/conffiles /vaultwarden_package/DEBIAN/conffiles
-+COPY Rocket.toml /vaultwarden_package/etc/vaultwarden
-+COPY debian/config.env /vaultwarden_package/etc/vaultwarden
-+COPY debian/vaultwarden.service /vaultwarden_package/usr/lib/systemd/system
-+COPY --from=vault /web-vault /vaultwarden_package/usr/share/vaultwarden/web-vault
-+COPY --from=build app/target/armv7-unknown-linux-gnueabihf/release/vaultwarden /vaultwarden_package/usr/local/bin
++COPY Rocket.toml /vaultwarden_package/etc/@@PACKAGEDIR@@
++COPY debian/config.env /vaultwarden_package/etc/@@PACKAGEDIR@@
++COPY debian/@@EXECUTABLENAME@@.service /vaultwarden_package/usr/lib/systemd/system
++COPY --from=vault /web-vault /vaultwarden_package/usr/share/@@PACKAGEDIR@@/web-vault
++COPY --from=build app/target/armv7-unknown-linux-gnueabihf/release/vaultwarden /vaultwarden_package/usr/local/bin/@@EXECUTABLENAME@@
 +
-+RUN dpkg-deb --build . vaultwarden.deb
++RUN dpkg-deb --build . @@PACKAGEDIR@@.deb

--- a/postinst.dist
+++ b/postinst.dist
@@ -1,0 +1,5 @@
+#!/bin/sh
+DIR_MODE=0700 adduser --system --home /var/lib/@@PACKAGEDIR@@ @@SERVICEUSER@@
+chmod 700 /var/lib/@@PACKAGEDIR@@
+chmod 600 /etc/@@PACKAGEDIR@@/config.env
+chmod 600 /etc/@@PACKAGEDIR@@/Rocket.toml

--- a/service.dist
+++ b/service.dist
@@ -4,15 +4,15 @@ After=network.target
 
 [Service]
 Type=simple
-User=vaultwarden
-ExecStart=/usr/local/bin/vaultwarden
+User=@@SERVICEUSER@@
+ExecStart=/usr/local/bin/@@EXECUTABLENAME@@
 PrivateTmp=true
 PrivateDevices=true
 ProtectHome=true
 ProtectSystem=strict
-WorkingDirectory=/etc/vaultwarden
-ReadWriteDirectories=/var/lib/vaultwarden
-EnvironmentFile=/etc/vaultwarden/config.env
+WorkingDirectory=/etc/@@PACKAGEDIR@@
+ReadWriteDirectories=/var/lib/@@PACKAGEDIR@@
+EnvironmentFile=/etc/@@PACKAGEDIR@@/config.env
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds support for configuring the package creation process.

To create a package which is fully compatible with the old `bitwarden_rs` configuration, the following command line can be used

```shell
$ ./build.sh -o stretch -r 1.21.0 -p bitwarden-rs -u bitwarden -i bitwarden_rs
```

The `build.sh` script accepts the following new parameters:

- `-p` (Optional) Package name; default `vaultwarden`
- `-i` (Optional) Package directory; default `vaultwarden`
- `-u` (Optional) Service user; default `vaultwarden`
- `-e` (Optional) Name of the vaultwarden (bitwarden_rs) executable; default `vaultwarden`
