### PR TITLE
Fix build for 1.25.0

### DIFF
--- a/conffiles.dist
+++ b/conffiles.dist
@@ -1,2 +1,1 @@
-/etc/@@PACKAGEDIR@@/Rocket.toml
 /etc/@@PACKAGEDIR@@/config.env

--- a/patch/amd64/Dockerfile.patch
+++ b/patch/amd64/Dockerfile.patch
@@ -1,6 +1,6 @@
 --- git/docker/amd64/Dockerfile	2021-02-12 11:45:13.762372371 +0100
 +++ Dockerfile	2021-02-12 11:59:56.727518522 +0100
-@@ -111,3 +111,24 @@
+@@ -111,3 +111,23 @@
  WORKDIR /
  ENTRYPOINT ["/usr/bin/dumb-init", "--"]
  CMD ["/start.sh"]
@@ -18,7 +18,6 @@
 +COPY debian/control /vaultwarden_package/DEBIAN/control
 +COPY debian/postinst /vaultwarden_package/DEBIAN/postinst
 +COPY debian/conffiles /vaultwarden_package/DEBIAN/conffiles
-+COPY Rocket.toml /vaultwarden_package/etc/@@PACKAGEDIR@@
 +COPY debian/config.env /vaultwarden_package/etc/@@PACKAGEDIR@@
 +COPY debian/@@EXECUTABLENAME@@.service /vaultwarden_package/usr/lib/systemd/system
 +COPY --from=vault /web-vault /vaultwarden_package/usr/share/@@PACKAGEDIR@@/web-vault

--- a/patch/armv7/Dockerfile.patch
+++ b/patch/armv7/Dockerfile.patch
@@ -1,6 +1,6 @@
 --- git/docker/armv7/Dockerfile	2021-02-12 11:45:13.763372371 +0100
 +++ Dockerfile	2021-02-12 12:25:50.078877369 +0100
-@@ -157,3 +157,24 @@
+@@ -157,3 +157,23 @@
  WORKDIR /
  ENTRYPOINT ["/usr/bin/dumb-init", "--"]
  CMD ["/start.sh"]
@@ -18,7 +18,6 @@
 +COPY debian/control /vaultwarden_package/DEBIAN/control
 +COPY debian/postinst /vaultwarden_package/DEBIAN/postinst
 +COPY debian/conffiles /vaultwarden_package/DEBIAN/conffiles
-+COPY Rocket.toml /vaultwarden_package/etc/@@PACKAGEDIR@@
 +COPY debian/config.env /vaultwarden_package/etc/@@PACKAGEDIR@@
 +COPY debian/@@EXECUTABLENAME@@.service /vaultwarden_package/usr/lib/systemd/system
 +COPY --from=vault /web-vault /vaultwarden_package/usr/share/@@PACKAGEDIR@@/web-vault

--- a/postinst.dist
+++ b/postinst.dist
@@ -2,4 +2,3 @@
 DIR_MODE=0700 adduser --system --group --home /var/lib/@@PACKAGEDIR@@ @@SERVICEUSER@@
 chmod 700 /var/lib/@@PACKAGEDIR@@
 chmod 600 /etc/@@PACKAGEDIR@@/config.env
-chmod 600 /etc/@@PACKAGEDIR@@/Rocket.toml


### PR DESCRIPTION
This removes all references to `Rocket.toml` which is no longer needed for Vaultwarden version 1.25.0.
It was removed with commit [0b7d6bf6df5a83dcc95d063baa04d8818eb9d7db](https://github.com/dani-garcia/vaultwarden/commit/0b7d6bf6df5a83dcc95d063baa04d8818eb9d7db#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR334), the json size limit is now configured via code.

While this pull requests fixes the deb build, an upgrade from previous versions to 1.25.0 may result in a not starting vaultwarden service. Since it tries to read a left over `Rocket.toml` but has not enough permissions to do so.
Deleting `/etc/vaultwarden/Rocket.toml` resolves this.

@greizgh Do you have any ideas how the upgrade process can be smoothed?  
Also what is your opinion on still supporting building earlier versions, where now the `Rocket.toml` would be missing.

Closes #41 