### PR TITLE
Do not build unneeded runtime image

### DIFF
--- a/patch/amd64/Dockerfile.patch
+++ b/patch/amd64/Dockerfile.patch
@@ -1,10 +1,9 @@
---- git/docker/amd64/Dockerfile	2021-02-12 11:45:13.762372371 +0100
-+++ Dockerfile	2021-02-12 11:59:56.727518522 +0100
-@@ -111,3 +111,23 @@
- WORKDIR /
- ENTRYPOINT ["/usr/bin/dumb-init", "--"]
- CMD ["/start.sh"]
-+
+--- git/docker/amd64/Dockerfile	2022-12-24 16:59:28.554597529 +0100
++++ Dockerfile	2022-12-24 18:12:24.069923032 +0100
+@@ -84,6 +84,26 @@
+ # hadolint ignore=DL3059
+ RUN cargo build --features ${DB} --release
+ 
 +####################### dpkg target ##########################
 +FROM build as dpkg
 +RUN mkdir /outdir
@@ -24,3 +23,7 @@
 +COPY --from=build app/target/release/vaultwarden /vaultwarden_package/usr/local/bin/@@EXECUTABLENAME@@
 +
 +RUN dpkg-deb --build . /outdir/@@PACKAGEDIR@@.deb
++
+ ######################## RUNTIME IMAGE  ########################
+ # Create a new stage with a minimal image
+ # because we already have a binary built

--- a/patch/armv7/Dockerfile.patch
+++ b/patch/armv7/Dockerfile.patch
@@ -1,10 +1,9 @@
---- git/docker/armv7/Dockerfile	2021-02-12 11:45:13.763372371 +0100
-+++ Dockerfile	2021-02-12 12:25:50.078877369 +0100
-@@ -157,3 +157,23 @@
- WORKDIR /
- ENTRYPOINT ["/usr/bin/dumb-init", "--"]
- CMD ["/start.sh"]
-+
+--- git/docker/armv7/Dockerfile	2022-12-24 15:34:46.644360901 +0100
++++ Dockerfile	2022-12-24 18:15:38.065904150 +0100
+@@ -104,6 +104,26 @@
+ # hadolint ignore=DL3059
+ RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabihf
+ 
 +####################### dpkg target ##########################
 +FROM build as dpkg
 +RUN mkdir /outdir
@@ -24,3 +23,7 @@
 +COPY --from=build app/target/armv7-unknown-linux-gnueabihf/release/vaultwarden /vaultwarden_package/usr/local/bin/@@EXECUTABLENAME@@
 +
 +RUN dpkg-deb --build . /outdir/@@PACKAGEDIR@@.deb
++
+ ######################## RUNTIME IMAGE  ########################
+ # Create a new stage with a minimal image
+ # because we already have a binary built


### PR DESCRIPTION
The runtime image was not the last stage thus it was always build and left as untagged image. We can improve that. Refer to the docs for the `docker build --target` option:

> Commands after the target stage will be skipped.

Ref: https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target

This commit simply moves the dpkg build stage patch above the runtime image stage.