### PR TITLE
Mention Debian 11 (bullseye) in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ cd vaultwarden-debian
 The `build.sh` script will build vaultwarden for the same Debian version which targets vaultwarden.
 That means, to build vaultwarden v1.19.0, make sure to checkout tag `v1.19.0` of this project.
 
-To compile for a different Debian version, specify the release name (e.g. Stretch, Buster) using the `-o` option. You can compile for arm32v7 or amd64 architecture using the `-a` option, only the Buster (default) release of debian is supported by arm32v7.
+To compile for a different Debian version, specify the release name (e.g. Buster, Bullseye) using the `-o` option. You can compile for arm32v7 or amd64 architecture using the `-a` option, only the Buster (default) release of debian is supported by arm32v7.
 
 ```
-./build.sh -o stretch
+./build.sh -o bullseye
 ```
 
 ## Post installation


### PR DESCRIPTION
I have been using this build script on Debian Bullseye and targeting Debian Bullseye. The docs should give an up-to-date and supported example.

I first thought to change the default target of the script, but the docs mention that only buster supports the arm target. I build for amd64 so I have not checked the arm side. Probably best to leave it so that both ARCHs can be build.