### PR TITLE
Many package fixes

### DIFF
--- a/control.dist
+++ b/control.dist
@@ -3,5 +3,6 @@ Architecture: -
 Maintainer: Greizgh <greizgh+vaultwarden@ephax.org>
 Priority: optional
 Version: -
+Depends: @@VAULTWARDEN_DEPS@@, systemd | systemd-standalone-sysusers | opensysusers, systemd | default-systemd-tmpfiles | systemd-tmpfiles | systemd-standalone-tmpfiles
 Description: Unofficial Bitwarden compatible server written in Rust
 Homepage: https://github.com/greizgh/vaultwarden-debian

--- a/patch/amd64/Dockerfile.patch
+++ b/patch/amd64/Dockerfile.patch
@@ -1,26 +1,31 @@
---- git/docker/amd64/Dockerfile	2022-12-24 16:59:28.554597529 +0100
-+++ Dockerfile	2022-12-24 18:12:24.069923032 +0100
-@@ -84,6 +84,26 @@
- # hadolint ignore=DL3059
+--- git/docker/amd64/Dockerfile	2023-07-29 15:42:52.131945764 -0500
++++ Dockerfile	2023-07-29 16:18:19.915440456 -0500
+@@ -77,6 +77,31 @@
+ # your actual source files being built
  RUN cargo build --features ${DB} --release
  
 +####################### dpkg target ##########################
 +FROM build as dpkg
 +RUN mkdir /outdir
 +RUN mkdir -p /vaultwarden_package/DEBIAN
-+RUN mkdir -p /vaultwarden_package/usr/local/bin
 +RUN mkdir -p /vaultwarden_package/usr/lib/systemd/system
++RUN mkdir -p /vaultwarden_package/usr/lib/sysusers.d
++RUN mkdir -p /vaultwarden_package/usr/lib/tmpfiles.d
 +RUN mkdir -p /vaultwarden_package/etc/@@PACKAGEDIR@@
 +RUN mkdir -p /vaultwarden_package/usr/share/@@PACKAGEDIR@@
 +
 +WORKDIR /vaultwarden_package
 +COPY debian/control /vaultwarden_package/DEBIAN/control
 +COPY debian/postinst /vaultwarden_package/DEBIAN/postinst
++COPY debian/postrm /vaultwarden_package/DEBIAN/postrm
++COPY debian/prerm /vaultwarden_package/DEBIAN/prerm
 +COPY debian/conffiles /vaultwarden_package/DEBIAN/conffiles
-+COPY debian/config.env /vaultwarden_package/etc/@@PACKAGEDIR@@
++COPY --chmod=600 debian/config.env /vaultwarden_package/etc/@@PACKAGEDIR@@
 +COPY debian/@@EXECUTABLENAME@@.service /vaultwarden_package/usr/lib/systemd/system
++COPY debian/sysusers.conf /vaultwarden_package/usr/lib/sysusers.d/@@PACKAGEDIR@@.conf
++COPY debian/tmpfiles.conf /vaultwarden_package/usr/lib/tmpfiles.d/@@PACKAGEDIR@@.conf
 +COPY --from=vault /web-vault /vaultwarden_package/usr/share/@@PACKAGEDIR@@/web-vault
-+COPY --from=build app/target/release/vaultwarden /vaultwarden_package/usr/local/bin/@@EXECUTABLENAME@@
++COPY --from=build app/target/release/vaultwarden /vaultwarden_package/usr/bin/@@EXECUTABLENAME@@
 +
 +RUN dpkg-deb --build . /outdir/@@PACKAGEDIR@@.deb
 +

--- a/patch/armv7/Dockerfile.patch
+++ b/patch/armv7/Dockerfile.patch
@@ -1,26 +1,31 @@
---- git/docker/armv7/Dockerfile	2022-12-24 15:34:46.644360901 +0100
-+++ Dockerfile	2022-12-24 18:15:38.065904150 +0100
-@@ -104,6 +104,26 @@
- # hadolint ignore=DL3059
+--- git/docker/armv7/Dockerfile	2023-07-29 13:22:34.026096436 -0500
++++ Dockerfile	2023-07-29 16:19:10.711762795 -0500
+@@ -96,6 +96,31 @@
+ # your actual source files being built
  RUN cargo build --features ${DB} --release --target=armv7-unknown-linux-gnueabihf
  
 +####################### dpkg target ##########################
 +FROM build as dpkg
 +RUN mkdir /outdir
 +RUN mkdir -p /vaultwarden_package/DEBIAN
-+RUN mkdir -p /vaultwarden_package/usr/local/bin
 +RUN mkdir -p /vaultwarden_package/usr/lib/systemd/system
++RUN mkdir -p /vaultwarden_package/usr/lib/sysusers.d
++RUN mkdir -p /vaultwarden_package/usr/lib/tmpfiles.d
 +RUN mkdir -p /vaultwarden_package/etc/@@PACKAGEDIR@@
 +RUN mkdir -p /vaultwarden_package/usr/share/@@PACKAGEDIR@@
 +
 +WORKDIR /vaultwarden_package
 +COPY debian/control /vaultwarden_package/DEBIAN/control
 +COPY debian/postinst /vaultwarden_package/DEBIAN/postinst
++COPY debian/postrm /vaultwarden_package/DEBIAN/postrm
++COPY debian/prerm /vaultwarden_package/DEBIAN/prerm
 +COPY debian/conffiles /vaultwarden_package/DEBIAN/conffiles
-+COPY debian/config.env /vaultwarden_package/etc/@@PACKAGEDIR@@
++COPY --chmod=600 debian/config.env /vaultwarden_package/etc/@@PACKAGEDIR@@
 +COPY debian/@@EXECUTABLENAME@@.service /vaultwarden_package/usr/lib/systemd/system
++COPY debian/sysusers.conf /vaultwarden_package/usr/lib/sysusers.d/@@PACKAGEDIR@@.conf
++COPY debian/tmpfiles.conf /vaultwarden_package/usr/lib/tmpfiles.d/@@PACKAGEDIR@@.conf
 +COPY --from=vault /web-vault /vaultwarden_package/usr/share/@@PACKAGEDIR@@/web-vault
-+COPY --from=build app/target/armv7-unknown-linux-gnueabihf/release/vaultwarden /vaultwarden_package/usr/local/bin/@@EXECUTABLENAME@@
++COPY --from=build app/target/armv7-unknown-linux-gnueabihf/release/vaultwarden /vaultwarden_package/usr/bin/@@EXECUTABLENAME@@
 +
 +RUN dpkg-deb --build . /outdir/@@PACKAGEDIR@@.deb
 +

--- a/postinst.dist
+++ b/postinst.dist
@@ -1,4 +1,32 @@
 #!/bin/sh
-DIR_MODE=0700 adduser --system --group --home /var/lib/@@PACKAGEDIR@@ @@SERVICEUSER@@
-chmod 700 /var/lib/@@PACKAGEDIR@@
-chmod 600 /etc/@@PACKAGEDIR@@/config.env
+set -e
+
+# Automatically added by dh_installsysusers/13.11.4
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+   systemd-sysusers ${DPKG_ROOT:+--root="$DPKG_ROOT"} @@PACKAGEDIR@@.conf
+fi
+
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	if [ -x "$(command -v systemd-tmpfiles)" ]; then
+		systemd-tmpfiles ${DPKG_ROOT:+--root="$DPKG_ROOT"} --create @@PACKAGEDIR@@.conf >/dev/null || true
+	fi
+fi
+
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	if deb-systemd-helper --quiet is-enabled '@@PACKAGEDIR@@.service'; then
+		# Creates new symlinks on upgrades if the unit file has changed.
+		deb-systemd-helper enable '@@PACKAGEDIR@@.service' >/dev/null || true
+	else
+		# Update the statefile to add new symlinks (if any), which need to be
+		# cleaned up on purge. Also remove old symlinks.
+		deb-systemd-helper update-state '@@PACKAGEDIR@@.service' >/dev/null || true
+	fi
+fi
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	if [ -d /run/systemd/system ]; then
+		systemctl --system daemon-reload >/dev/null || true
+		if systemctl --system is-active '@@PACKAGEDIR@@.service'; then
+			deb-systemd-invoke restart '@@PACKAGEDIR@@.service' >/dev/null || true
+		fi
+	fi
+fi

--- a/postrm.dist
+++ b/postrm.dist
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+# Automatically added by dh_installsystemd/13.11.4
+if [ "$1" = remove ] && [ -d /run/systemd/system ] ; then
+	systemctl --system daemon-reload >/dev/null || true
+fi
+# End automatically added section
+# Automatically added by dh_installsystemd/13.11.4
+if [ "$1" = "purge" ]; then
+	if [ -x "/usr/bin/deb-systemd-helper" ]; then
+		deb-systemd-helper purge '@@PACKAGEDIR@@.service' >/dev/null || true
+	fi
+fi
+# End automatically added section

--- a/prerm.dist
+++ b/prerm.dist
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+# Automatically added by dh_installsystemd/13.11.4
+if [ -z "${DPKG_ROOT:-}" ] && [ "$1" = remove ] && [ -d /run/systemd/system ] ; then
+	deb-systemd-invoke stop '@@PACKAGEDIR@@.service' >/dev/null || true
+fi
+# End automatically added section

--- a/service.dist
+++ b/service.dist
@@ -1,11 +1,11 @@
 [Unit]
-Description=Bitwarden API server
+Description=Vaultwarden API server
 After=network.target
 
 [Service]
 Type=simple
 User=@@SERVICEUSER@@
-ExecStart=/usr/local/bin/@@EXECUTABLENAME@@
+ExecStart=/usr/bin/@@EXECUTABLENAME@@
 PrivateTmp=true
 PrivateDevices=true
 ProtectHome=true

--- a/sysusers.conf
+++ b/sysusers.conf
@@ -1,0 +1,2 @@
+# Setup the user for the @@PACKAGEDIR@@ service
+u @@SERVICEUSER@@ - "@@PACKAGEDIR@@ service user" /var/lib/@@PACKAGEDIR@@

--- a/tmpfiles.conf
+++ b/tmpfiles.conf
@@ -1,0 +1,4 @@
+# Data directory for @@PACKAGEDIR@@
+d /var/lib/@@PACKAGEDIR@@ 0700 @@SERVICEUSER@@ root - -
+# Adjust the permissions of this file to be owned by @@SERVICEUSER@@
+z /etc/@@PACKAGEDIR@@/config.env 0600 @@SERVICEUSER@@ root - -


### PR DESCRIPTION
- Automatically add dependencies for Bookworm and Bullseye
- Exit early if user tries to use a Debian version besides Bookworm and Bullseye (Buster and older are broken, Trixie and Sid don't have Rust images)
- Add appropriate dependency depending on database driver selected
- Recommend mariadb-server if mysql driver is suggested, recommend postgresql if postgresql driver is selected
- Use tmpfiles to create data directory and to adjust the config permissions if the user has modified them
- Use sysusers to create the vaultwarden user and group
- Move vaultwarden binary to /usr/bin/vaultwarden. Binaries shipped with packages should not be in /usr/local/bin (this is considered a package fail).
- Restart the vaultwarden service if it was running at the time the package was updated
- Stop the vaultwarden service if the package is removed
- Set up the correct systemd hooks so that daemon-reload happens at the right time and so that the unit symlinks are properly removed if the package is purged.

This removes the errors about the vaultwarden user already existing upon package installation.
Closes #45